### PR TITLE
Dynamic home link

### DIFF
--- a/app/header.tsx
+++ b/app/header.tsx
@@ -1,8 +1,34 @@
+'use client';
+
+import { useSelectedLayoutSegments } from 'next/navigation';
+
 import { cn } from '@/lib/utils';
 
-import { HomeLink } from './home-link';
+import { DEFAULT_HOMELINK, HomeLink } from './home-link';
+
+const LAYOUT_SEGMENT_TO_LINK: Record<string, HomeLink> = {
+  '/': {
+    href: '/scenarios',
+    label: 'Start',
+  },
+  scenarios: {
+    href: '/',
+    label: 'Home',
+  },
+  chat: {
+    href: '/scenarios',
+    label: 'Scenarios',
+  },
+  evaluation: {
+    href: '/scenarios',
+    label: 'Scenarios',
+  },
+};
 
 export function Header() {
+  const segments = useSelectedLayoutSegments();
+  const lastSegment = segments.at(-1);
+
   return (
     <div
       className={cn(
@@ -17,7 +43,12 @@ export function Header() {
       }}
     >
       <div className='px-4 py-2'>
-        <HomeLink href='/' fontSize='24px' />
+        <HomeLink
+          homeLink={
+            LAYOUT_SEGMENT_TO_LINK[lastSegment ?? '/'] ?? DEFAULT_HOMELINK
+          }
+          fontSize='24px'
+        />
       </div>
     </div>
   );

--- a/app/home-link.tsx
+++ b/app/home-link.tsx
@@ -6,11 +6,27 @@ import { useEffect, useState } from 'react';
 
 import { AnimatedText } from '@/components/animated-text';
 
-type HomeLinkProps = {
+export type HomeLink = {
   /**
    * The path to navigate to when the user clicks on this component.
    */
   href: string;
+  /**
+   * The label to show on the home link.
+   */
+  label: string;
+};
+
+export const DEFAULT_HOMELINK: HomeLink = {
+  href: '/',
+  label: 'Home',
+};
+
+type HomeLinkProps = {
+  /**
+   * The {@link HomeLink} object that contains the path and label for the home link.
+   */
+  homeLink: HomeLink;
   /**
    * The font size of the heading text as string.
    */
@@ -54,7 +70,7 @@ export function HomeLink(props: HomeLinkProps) {
   function handleLinkClick() {
     setIsBeforeRouting(true);
     setTimeout(() => {
-      router.push(props.href);
+      router.push(props.homeLink.href);
     }, 200);
   }
 
@@ -113,9 +129,7 @@ export function HomeLink(props: HomeLinkProps) {
                 fontSize: props.fontSize,
               }}
             >
-              <AnimatedText yOffset={20}>
-                {props.href === '/' ? 'Home' : 'Start'}
-              </AnimatedText>
+              <AnimatedText yOffset={20}>{props.homeLink.label}</AnimatedText>
             </div>
           </motion.div>
         </motion.div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,11 @@ import { HomeLink } from './home-link';
 export default function Page() {
   return (
     <main className='flex items-center justify-center px-4'>
-      <HomeLink href='/scenarios' fontSize='10vw' showWhenOnHomePage />
+      <HomeLink
+        homeLink={{ href: '/scenarios', label: 'Start' }}
+        fontSize='10vw'
+        showWhenOnHomePage
+      />
     </main>
   );
 }


### PR DESCRIPTION
This PR makes `<HomeLink>` dynamic based on the route segment. Because in chat and evaluation, the home link should direct user back to scenarios page instead of home page. So this dynamic selection is required.


'/' >>> Scenarios page
'/scenarios' >>> Home page
'/chat' >>> Scenarios page
'/evaluation' >>> Scenarios page